### PR TITLE
Fix: Redis ValueOperations에서 get과 delete를 분리

### DIFF
--- a/src/main/java/kfoodbox/common/util/RedisClient.java
+++ b/src/main/java/kfoodbox/common/util/RedisClient.java
@@ -26,6 +26,8 @@ public class RedisClient {
 
     public Optional<String> getSignupAuthenticationNumberAndDelete(String email) {
         String key = String.format("%s/%s", SIGNUP_AUTHENTICATION_NUMBER_PREFIX, email);
-        return Optional.ofNullable(valueOperations.getAndDelete(key));
+        String value = valueOperations.get(key);
+        valueOperations.getOperations().delete(key);
+        return Optional.ofNullable(value);
     }
 }


### PR DESCRIPTION
- Redis 6.2.0 부터만 GetAndDelete 연산지 지원됨에 따라, 현재 EC2 redis 버전은 6.0.16이므로 연산 불가
- 따라서 Get 연산과 Delete 연산 분리